### PR TITLE
Dont overwrite rustdoc files

### DIFF
--- a/src/public_api.rs
+++ b/src/public_api.rs
@@ -226,7 +226,7 @@ pub fn get_changes(
             .manifest_path(c.manifest_path())
             .build()?;
 
-        // Backup this file with it name appended as .new
+        // Backup the file to avoid overwriting it in the next `rustdoc_json::Builder` invocation:
         let _ = std::fs::copy(&json_path, json_path.with_extension("new"));
         let json_path = json_path.with_extension("new");
 
@@ -251,7 +251,7 @@ pub fn get_changes(
             .manifest_path(upstream.manifest_path())
             .build()?;
 
-        // Backup this file with it name appended as .ol
+        // Backup the file to a known-good location:
         let _ = std::fs::copy(&json_path, json_path.with_extension("old"));
         let json_path = json_path.with_extension("old");
 

--- a/src/public_api.rs
+++ b/src/public_api.rs
@@ -226,6 +226,10 @@ pub fn get_changes(
             .manifest_path(c.manifest_path())
             .build()?;
 
+        // Backup this file with it name appended as .new
+        let _ = std::fs::copy(&json_path, json_path.with_extension("new"));
+        let json_path = json_path.with_extension("new");
+
         let new = cargo_semver_checks::Rustdoc::from_path(&json_path);
         let new_diff = public_api::Builder::from_rustdoc_json(&json_path).build()?;
         let mut new = cargo_semver_checks::Check::new(new);
@@ -246,6 +250,10 @@ pub fn get_changes(
             .silent(silent)
             .manifest_path(upstream.manifest_path())
             .build()?;
+
+        // Backup this file with it name appended as .ol
+        let _ = std::fs::copy(&json_path, json_path.with_extension("old"));
+        let json_path = json_path.with_extension("old");
 
         let path = c.root().strip_prefix(workspace.root()).unwrap();
         let old = cargo_semver_checks::Rustdoc::from_path(&json_path);


### PR DESCRIPTION
The `cargo_semver_checks::Rustdoc::from_path` constructor only stores the path itself, without parsing the file.  
This causes an issue, since the struct is then later used here:  
https://github.com/paritytech/parity-publish/blob/f0d45e7a1191ba19e76776926c73a3155a2a57e0/src/public_api.rs#L253

Changes:
- Copy both rustdoc files to known-good locations for later use.