### PR TITLE
Check max allowed SemVer bump

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -164,7 +164,7 @@ pub struct Prdoc {
     pub crates: Vec<String>,
     /// The maximum bump that is allowed for any crate to happen. Only checked if `validate` is set.
     #[arg(long, value_enum)]
-    pub max_allowed_bump: Option<BumpKind>,
+    pub max_bump: Option<BumpKind>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use std::{
     io::{stderr, stdout, IsTerminal},
     path::PathBuf,
 };
+use crate::plan::BumpKind;
 
 use clap::{ArgAction, Parser};
 use termcolor::{ColorChoice, StandardStream};
@@ -161,6 +162,9 @@ pub struct Prdoc {
     pub toolchain: String,
     #[arg(default_values_t = Vec::<String>::new())]
     pub crates: Vec<String>,
+    /// The maximum bump that is allowed for any crate to happen. Only checked if `validate` is set.
+    #[arg(long, value_enum)]
+    pub max_allowed_bump: Option<BumpKind>,
 }
 
 #[derive(Parser, Debug)]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -24,6 +24,7 @@ use crate::{
 
 #[derive(
     serde::Serialize, serde::Deserialize, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Clone,
+    Debug, clap::ValueEnum,
 )]
 pub enum BumpKind {
     #[default]

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -220,20 +220,20 @@ fn validate(args: &Args, prdoc: &Prdoc, w: &Workspace) -> Result<()> {
 
             if prdoc_bad || predicted_bad {
                 let location = if prdoc_bad && predicted_bad {
-                    "Bump specified in PR Doc and detected"
+                    "Specified and detected"
                 } else if prdoc_bad {
-                    "Bump specified in PR Doc"
+                    "Specified"
                 } else {
-                    "Detected bump"
+                    "Detected"
                 };
 
                 write!(
                     stdout,
-                    "    {} exceeds allowed bump level: ",
+                    "    {} bump exceeds allowed bump level: ",
                     location,
                 )?;
                 stdout.set_color(ColorSpec::new().set_bold(true))?;
-                write!(stdout, "{}", prdoc.bump)?;
+                write!(stdout, "{}", prdoc.bump.max(predicted))?;
                 stdout.set_color(ColorSpec::new().set_bold(false))?;
                 write!(stdout, " > ")?;
                 stdout.set_color(ColorSpec::new().set_bold(true))?;

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -241,6 +241,7 @@ fn validate(args: &Args, prdoc: &Prdoc, w: &Workspace) -> Result<()> {
                 ok = false;
             }
             if api_change.bump == BumpKind::Minor && prdoc.bump == BumpKind::Patch {
+                // just warn don't return 1 for this
                 writeln!(
                     stdout,
                     "    Minor API change found but prdoc specified {}",

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -214,18 +214,30 @@ fn validate(args: &Args, prdoc: &Prdoc, w: &Workspace) -> Result<()> {
         writeln!(stdout, "{}", predicted)?;
         stdout.set_color(ColorSpec::new().set_bold(false))?;
 
-        if let Some(max_bump) = max_bump {
-            if prdoc.bump > max_bump {
+        if let Some(max_allowed_bump) = max_bump {
+            let prdoc_bad = prdoc.bump > max_allowed_bump;
+            let predicted_bad = predicted > max_allowed_bump;
+
+            if prdoc_bad || predicted_bad {
+                let location = if prdoc_bad && predicted_bad {
+                    "Bump specified in PR Doc and detected"
+                } else if prdoc_bad {
+                    "Bump specified in PR Doc"
+                } else {
+                    "Detected bump"
+                };
+
                 write!(
                     stdout,
-                    "    Prdoc change exceeds allowed bump level: ",
+                    "    {} exceeds allowed bump level: ",
+                    location,
                 )?;
                 stdout.set_color(ColorSpec::new().set_bold(true))?;
                 write!(stdout, "{}", prdoc.bump)?;
                 stdout.set_color(ColorSpec::new().set_bold(false))?;
                 write!(stdout, " > ")?;
                 stdout.set_color(ColorSpec::new().set_bold(true))?;
-                writeln!(stdout, "{}", max_bump)?;
+                writeln!(stdout, "{}", max_allowed_bump)?;
                 stdout.set_color(ColorSpec::new().set_bold(false))?;
                 ok = false;
             }


### PR DESCRIPTION
Adds a `--max-allowed-bump` to the `prdoc` subcommand to restrict the maximal allowed bump kind.  
This can then be used for the backport CI, where we only allow up to `minor` changes.