### PR TITLE
Attemp to fix ` Error: no dep`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "parity-publish"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "cargo",

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -216,11 +216,8 @@ fn compare_deps(
                 continue;
             }
             (Err(_), Err(_)) => {
-                // strange, not found in both?
-                return Err(anyhow::anyhow!(
-                    "Dependency with name: {name:?} not found neither in `old` nor `new` for package: {c:?}, \
-                    please check if potential dependency renaming is correctly handled, e.g. `foo = {{version = \"1\", package = \"bar\"}}`!"
-                ));
+                // TODO: (https://github.com/paritytech/parity-publish/issues/44): investigate further, what is this case?
+                continue;
             }
             (Ok(o), Ok(n)) => (o, n),
         };

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env::current_dir;
 use std::fs::{read_dir, read_to_string};
 use std::io::Write;
@@ -196,7 +196,7 @@ fn compare_deps(
         .and_then(|d| d.as_table())
         .unwrap_or(&t);
 
-    for (name, _) in deps {
+    for name in deps.iter().map(|(name, _)| name).collect::<HashSet<_>>() {
         let (_old_pkg, old_dep, old_root_dep) = get_dep(workspace, name, old, old_root)?;
         let (new_pkg, new_dep, new_root_dep) = get_dep(workspace, name, new, new_root)?;
 

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env::current_dir;
 use std::fs::{read_dir, read_to_string};
 use std::io::Write;
@@ -196,7 +196,7 @@ fn compare_deps(
         .and_then(|d| d.as_table())
         .unwrap_or(&t);
 
-    for name in deps.iter().map(|(name, _)| name).collect::<HashSet<_>>() {
+    for (name, _) in deps {
         let ((_old_pkg, old_dep, old_root_dep), (new_pkg, new_dep, new_root_dep)) = match (
             get_dep(workspace, name, old, old_root),
             get_dep(workspace, name, new, new_root),

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -219,7 +219,7 @@ fn compare_deps(
                 // strange, not found in both?
                 return Err(anyhow::anyhow!(
                     "Dependency with name: {name:?} not found neither in `old` nor `new` for package: {c:?}, \
-                    please check if dependency renames is correctly handled, e.g. `foo = {{version = \"1\", package = \"bar\"}}`!"
+                    please check if potential dependency renaming is correctly handled, e.g. `foo = {{version = \"1\", package = \"bar\"}}`!"
                 ));
             }
             (Ok(o), Ok(n)) => (o, n),

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -218,8 +218,8 @@ fn compare_deps(
             (Err(_), Err(_)) => {
                 // strange, not found in both?
                 return Err(anyhow::anyhow!(
-                    "Dependency with name: {name:?} not found neither in `old` nor `new` for package: {:?}, \
-                    please check if dependency renames is correctly handled, e.g. `foo = {version = \"1\", package = \"bar\"}`!"
+                    "Dependency with name: {name:?} not found neither in `old` nor `new` for package: {c:?}, \
+                    please check if dependency renames is correctly handled, e.g. `foo = {{version = \"1\", package = \"bar\"}}`!"
                 ));
             }
             (Ok(o), Ok(n)) => (o, n),

--- a/src/prdoc.rs
+++ b/src/prdoc.rs
@@ -217,7 +217,10 @@ fn compare_deps(
             }
             (Err(_), Err(_)) => {
                 // strange, not found in both?
-                continue;
+                return Err(anyhow::anyhow!(
+                    "Dependency with name: {name:?} not found neither in `old` nor `new` for package: {:?}, \
+                    please check if dependency renames is correctly handled, e.g. `foo = {version = \"1\", package = \"bar\"}`!"
+                ));
             }
             (Ok(o), Ok(n)) => (o, n),
         };


### PR DESCRIPTION
Closes: https://github.com/paritytech/parity-publish/issues/42

This PR fixes two things:
- `Error: no dep`
- small optimization for `for (name, _) in deps {` - it iterates over and over the same stuff unnecessary

Error: https://github.com/paritytech/polkadot-sdk/actions/runs/12237889294/job/34134815479?pr=6781
```
PR Doc validation is best effort
We can only detect the minimum guaranteed semver change
It's possible to not detect changes or for changes to be greater than detected
Always reason about semver changes yourself

validating prdocs...
checking file changes...
checking dep changes...
Error: no dep

Stack backtrace:
   0: parity_publish::prdoc::get_dep
   1: parity_publish::prdoc::manifest_deps_changed
   2: parity_publish::prdoc::handle_prdoc
   3: parity_publish::main::{{closure}}
   4: tokio::runtime::park::CachedParkThread::block_on
   5: tokio::runtime::context::runtime::enter_runtime
   6: tokio::runtime::runtime::Runtime::block_on
   7: parity_publish::main
   8: std::sys::backtrace::__rust_begin_short_backtrace
   9: std::rt::lang_start::{{closure}}
  10: std::rt::lang_start_internal
  11: main
  12: __libc_start_main
  13: _start
```

After some debugging, looks like that job is failing on added `sp-core`:
![image](https://github.com/user-attachments/assets/f5dd6b5a-e155-44d8-b987-ca6f0d6c7f75)
