### PR TITLE
Fix plan when new crate is added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "parity-publish"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "cargo",


### PR DESCRIPTION
This PR: https://github.com/paritytech/polkadot-sdk/pull/6450 fails with this panic: https://github.com/paritytech/polkadot-sdk/actions/runs/12277797095/job/34258125756?pr=6450. The changes on this PR handles adding new crates gracefully when they're discovered in the `get_upstream` logic.