### PR TITLE
Add publish delay on publish crates workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "parity-publish"
-version = "0.10.15"
+version = "0.10.16"
 dependencies = [
  "anyhow",
  "cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parity-publish"
-version = "0.10.15"
+version = "0.10.16"
 edition = "2021"
 description = "A tool to manage publishing Parity's crates"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ conflicts in the shared target directory. Note that this skips build verificatio
 which may result in publishing broken crates. Consider running `cargo publish --dry-run`
 or `cargo package` beforehand to catch issues.
 
+`--publish-delay N` adds a delay of N seconds between parallel publish batches within a
+level. Each batch spawns up to `-j` concurrent `cargo publish` processes, so bursts of
+uploads can trigger crates.io rate limits on large releases. Defaults to `0` (no delay,
+current behavior). The inter-level 30s index-propagation wait is unaffected.
+
+```
+parity-publish apply --publish -j 8 --no-verify --publish-delay 15
+```
+
 The process is resumable: if it fails partway through, re-running will skip
 already-published crates automatically.
 

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -467,7 +467,8 @@ async fn publish_parallel(
 
         let level_start = Instant::now();
 
-        for chunk in level.chunks(jobs) {
+        let mut chunks = level.chunks(jobs).peekable();
+        while let Some(chunk) = chunks.next() {
             // Spawn all processes in the chunk simultaneously
             let mut children: Vec<(String, String, tokio::process::Child)> = Vec::new();
 
@@ -562,6 +563,14 @@ async fn publish_parallel(
                     .await
                     .context("failed to run cargo clean")?;
                 since_clean = 0;
+            }
+
+            if apply.publish_delay > 0 && chunks.peek().is_some() && !apply.dry_run {
+                let wait = Duration::from_secs(apply.publish_delay);
+                write!(stdout, "Waiting {}s before next batch...", wait.as_secs())?;
+                stdout.flush()?;
+                tokio::time::sleep(wait).await;
+                writeln!(stdout, " done")?;
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -271,6 +271,10 @@ pub struct Apply {
     /// Run `cargo clean` after every N published crates to free disk space (0 = disabled)
     #[arg(long, default_value = "0")]
     pub clean_every: usize,
+    /// Delay in seconds between parallel publish batches (only applies with `-j > 1`, 0 = no delay).
+    /// Useful to avoid hitting crates.io rate limits.
+    #[arg(long, default_value = "0")]
+    pub publish_delay: u64,
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Adds --publish-delay SECS to `apply` that sleeps between chunks within a level in parallel mode. Defaults to 0 (no delay, existing behavior). Inter-level 30s index-propagation wait is unaffected. Helps avoid crates.io rate limits on large releases where many back-to-back `cargo publish` bursts can trip throttling.