### PR TITLE
perf: use the sparse crates.io index instead of the git index

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -15,7 +15,18 @@ pub fn get_registry<'a>(workspace: &Workspace<'a>) -> Result<RegistrySource<'a>>
     let whitelist = workspace.members().map(|c| c.package_id()).collect();
     let config = workspace.gctx();
 
-    let mut reg = RegistrySource::remote(SourceId::crates_io(config)?, &whitelist, config)?;
+    // `SourceId::crates_io` is hardwired to the *git* index. Since every call
+    // here follows with `invalidate_cache`, that means refreshing a multi-GB git
+    // repository on every single invocation. Use the sparse index instead, which
+    // fetches only the index files for the crates actually being looked up.
+    //
+    // `crates_io_maybe_sparse_http` honours `registries.crates-io.protocol`, so
+    // anyone who has deliberately pinned the git protocol still gets it.
+    let mut reg = RegistrySource::remote(
+        SourceId::crates_io_maybe_sparse_http(config)?,
+        &whitelist,
+        config,
+    )?;
     reg.invalidate_cache();
 
     Ok(reg)


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #90 — base is `bd-yanked-version-bumps`, so this diff is one function. GitHub will retarget it to `main` when #90 merges. **It must not land before #90**; see *Ordering* below.

## Problem

`registry::get_registry` builds its source from `SourceId::crates_io`, which is hardwired to the **git** index — `crates_io_maybe_sparse_http` is the variant that honours the sparse protocol cargo has defaulted to since 1.70. And because every call follows it with `invalidate_cache()`, each invocation refreshes that git repository.

Locally that repo is **1.8 GB** (`~/.cargo/registry/index/github.com-*`) against **119 MB** for the sparse index. This is most of what `looking up crate data, this may take a while....` is waiting on.

## Fix

One call swapped. `crates_io_maybe_sparse_http` still returns the git source id if `registries.crates-io.protocol = "git"` is configured, so a deliberate pin keeps working.

Nothing else keys off the protocol, which is why the change stays this small:
- the `is_git()` checks in `plan.rs` are about *manifest* dependencies, not the registry
- `public_api.rs:182` builds its `RegistrySource` from `summary.source_id()`, so it follows automatically
- `registry.rs` builds its `Dependency` from `reg.source_id()`, so the source-equality check inside `dep.matches()` still holds
- `status`/`check`/`claim` go through the crates.io HTTP API and never touch this

## Measurements

Single-crate throwaway workspace, this machine:

| | `plan --new` | ignored index test |
|---|---|---|
| git index | did not finish in **7 min** — 100% CPU in git2, new pack growing at ~8 KB/s; killed | — |
| sparse index | **2.3 s** | **2.0 s** |

Caveats worth stating: that 7 minutes was a stale local git index doing delta resolution, so it is a worst case rather than the steady state, and a warm CI runner will be faster. The point is that the cost is paid per invocation because of `invalidate_cache()`, and it scales with the size of the whole index rather than with the number of crates being looked up.

Side benefit: `registry::tests::yanked_versions_are_visible_in_the_index` (added in #90, `#[ignore]`d) now runs in 2 s, so the yanked-version behaviour is cheap to verify against the real index.

## Ordering

This must land after #90. The git index masks the readiness bug fixed there — a single `block_until_ready()` makes every later query ready, because the fetch brings down the whole index. The sparse index needs more than one round (registry config first, then each crate's index file), so on its own this change would make every lookup return `Pending`, `get_upstream` would discard them all, and the planner would silently plan from local manifest versions.

That is not hypothetical — it is exactly what I hit while verifying #90 against the sparse index: `plan --new` reported `from = "0.3.1"` for a crate whose highest live release is `0.13.0`.

## Testing

`cargo test` — 18 passed. `cargo test -- --ignored` — 1 passed, against the live index. `plan --new` on the throwaway workspace returns the correct upstream version (`0.13.0`).

`cargo fmt` is still failing on pre-existing code in `apply.rs`, `edit.rs` and `restore.rs`; deliberately not touched here (running `cargo fmt` reformats the whole crate, which would bury this one-function diff). Happy to send that as its own PR.