### PR TITLE
chore: targeted security dep bumps, add CI, automate releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: check & test
+    runs-on: ubuntu-latest
+    env:
+      # The crate builds warning-free today; keep it that way.
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # reqwest's default-tls pulls in native-tls -> openssl on Linux, and
+      # cargo/git2 need libgit2's system deps. macOS uses Security.framework
+      # instead, so this path is only exercised here.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
+      # --locked fails if Cargo.lock is stale, so dependency PRs are verified
+      # against the exact lockfile they commit.
+      - name: cargo check
+        run: cargo check --all-targets --locked
+
+      - name: cargo test
+        run: cargo test --locked
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
+      # Informational only: the existing code has ~38 clippy warnings, so this
+      # deliberately does not pass -D warnings. Clear the backlog first, then
+      # promote this to a gating check.
+      - name: cargo clippy
+        run: cargo clippy --all-targets --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       # The crate builds warning-free today; keep it that way.
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #v2.9.2
 
       # reqwest's default-tls pulls in native-tls -> openssl on Linux, and
       # cargo/git2 need libgit2's system deps. macOS uses Security.framework
@@ -42,13 +42,13 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #v2.9.2
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+# Publishing is handled centrally by
+# https://github.com/paritytech/crates_publish_automation — this workflow only
+# packages the crate and dispatches to it. The crates.io token lives in that
+# repo, never here.
+#
+# Prerequisites (both are one-off, outside this repo):
+#   1. "parity-publish": ["parity-publish"] must be present in crates.ts of
+#      crates_publish_automation, otherwise the dispatch is rejected.
+#   2. parity-crate-owner must own the crate on crates.io. Already true here.
+name: Release
+
+on:
+  release:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Package & publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 #v2.9.2
+
+      # cargo package build-verifies, which needs the same system deps as ci.yml:
+      # reqwest's default-tls pulls native-tls -> openssl, and cargo/git2 need
+      # libgit2's deps.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
+      # The automation silently skips versions already on crates.io, so a tag
+      # that disagrees with Cargo.toml would produce a green run that published
+      # nothing. Fail loudly instead. Tag is read via env, not ${{ }}
+      # interpolation, so it cannot be injected into the shell.
+      - name: Check the release tag matches Cargo.toml
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          manifest="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          if [ "${TAG#v}" != "$manifest" ]; then
+            echo "::error::Release tag '$TAG' does not match Cargo.toml version '$manifest'."
+            exit 1
+          fi
+          echo "Releasing parity-publish $manifest"
+
+      # Single-crate repo, so no -p/--exclude filtering is needed. Verification
+      # is left on: it is the only thing that proves the packaged tarball
+      # actually builds. Add --no-verify if release runs get too slow.
+      - name: Cargo package
+        run: cargo package --locked
+
+      # Must stay named "crates" — the automation picks the first artifact of
+      # the triggering run and expects .crate files.
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crates
+          path: target/package/*.crate
+          if-no-files-found: error
+
+      - name: Generate content write token
+        id: generate-content-write-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CRATES_NPM_PUBLISHING_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CRATES_NPM_PUBLISHING_APP_PRIVATE_KEY }}
+          owner: paritytech
+
+      - name: Trigger publishing in the crates_publish_automation repo
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae #v3.0.0
+        with:
+          route: POST /repos/paritytech/crates_publish_automation/actions/workflows/publish.yml/dispatches
+          ref: main
+          inputs: '${{ format(''{{ "repo": "{0}", "run_id": "{1}" }}'', github.repository, github.run_id) }}'
+        env:
+          GITHUB_TOKEN: ${{steps.generate-content-write-token.outputs.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -303,9 +303,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -606,6 +606,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +799,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1416,8 +1436,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -3502,6 +3536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,15 +3916,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3908,9 +3947,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -4228,13 +4267,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4276,15 +4317,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -4292,18 +4328,19 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4332,6 +4369,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4470,15 +4522,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4888,7 +4939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4909,7 +4960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5063,12 +5114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,9 +5253,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
Three related changes: bump the transitive dependencies that carry known
advisories, add the build CI this repo never had, and wire up automated
releases through `crates_publish_automation`.

## 1. Targeted dependency bumps (`Cargo.lock` only)

| Crate | Old → New | Why |
|---|---|---|
| `openssl` | 0.10.68 → **0.10.81** | [RUSTSEC-2025-0022] use-after-free in `Md::fetch`/`Cipher::fetch` (affects `>=0.10.39,<0.10.72`), plus [RUSTSEC-2025-0004]. Reached via `native-tls` ← `reqwest` `default-tls`, which only compiles on Linux |
| `ring` | 0.17.8 → **0.17.14** | [RUSTSEC-2025-0009], patched in 0.17.12. Reached via `rustls` ← `reqwest` ← `tame-index` ← `cargo-semver-checks` |
| `tar` | 0.4.44 → **0.4.46** | symlink/directory collision chmod fix, PAX size handling. Reached via `cargo`, which is on this tool's packaging path |
| `bytes` | 1.9.0 → **1.12.1** | integer overflow in `BytesMut::reserve` |
| `quinn-proto` | 0.11.9 → **0.11.16** | lockfile-only entry, see below |
| `rand` | 0.8.5 → **0.10.2** | pulled in by `quinn-proto` 0.11.16 |

This replaces eight stale single-crate dependabot PRs. They were opened
between 4 and 15 months ago and each rewrites `Cargo.lock`, so merging them
individually means each merge conflicts the remaining seven — #56 and #64 are
already `DIRTY`. Doing it in one commit also lands strictly newer versions
than any of those PRs proposed.

A bare `cargo update` was deliberately avoided: it sweeps ~250 crates
including major bumps of `uuid` and `zerocopy`, for no additional security
benefit.

`quinn-proto` and `rand` 0.8.5 are **never compiled** — `quinn` is `reqwest`'s
optional `http3` dependency and is not enabled, so `cargo tree -i quinn
--target all --all-features` finds nothing. They are bumped only so the
corresponding PRs can be closed rather than recreated.

### Dependabot PRs this supersedes

Already fixed on `main`, safe to close as obsolete:
- #53 `crossbeam-channel` 0.5.15 — `main` is already at 0.5.15
- #64 `tracing-subscriber` 0.3.20 — `main` is already at 0.3.22

Superseded by this PR: #89, #56, #81, #73, #78, #88

## 2. `ci.yml` — the missing build CI

This repo had no `.github/` directory at all. Dependency PRs carried only the
CLA and Socket Security checks and were never compiled, which is precisely why
the backlog accumulated.

- `test` job gates on `cargo check --all-targets --locked` and `cargo test
  --locked` with `RUSTFLAGS=-D warnings`. `--locked` means a dependency PR is
  verified against the exact lockfile it commits.
- `clippy` job is **informational** — it deliberately omits `-D warnings`.

`cargo clippy -D warnings` and `cargo fmt --check` are both left non-gating on
purpose: the existing code has ~38 clippy warnings and does not satisfy
`cargo fmt`, so gating either would mean a red CI from day one. Both need
their own cleanup pass; the workflow says so in comments.

## 3. `release.yml` — automated publishing

Publishing moves to [`crates_publish_automation`][cpa], which runs
`cargo publish` as `parity-crate-owner`. **No crates.io token is needed in
this repo.** On a GitHub release this workflow packages the crate, uploads it
as artifact `crates`, and dispatches the automation's `publish.yml`.

Follows that repo's README snippet, with three additions:

- **A tag/version guard.** The automation silently skips versions already on
  crates.io, so a mistagged release would be a green run that published
  nothing. This fails loudly instead. Accepts both `v0.10.17` and `0.10.17`;
  the tag is read via `env:` rather than `${{ }}` interpolation so it cannot
  be injected into the shell.
- **System deps**, since `cargo package` build-verifies and hits the same
  openssl/libgit2 paths as `ci.yml`.
- **`if-no-files-found: error`**, so an empty artifact fails here rather than
  downstream in the automation.

Verification is left on; `--no-verify` is the documented escape hatch if
release runs get too slow. The artifact must stay named `crates` — the
automation takes the first artifact of the triggering run.

## Blocking follow-up

`crates.ts` in `crates_publish_automation` is currently empty, so nothing is
allowlisted and a dispatch would be rejected. Companion PR adds the entry:
paritytech/crates_publish_automation#1

`parity-crate-owner` already owns `parity-publish` on crates.io, so no
`cargo owner --add` is needed.

Two things worth a second opinion:
- That repo's README contradicts itself on auth — the YAML snippet uses
  `actions/create-github-app-token` with
  `CRATES_NPM_PUBLISHING_APP_CLIENT_ID`/`_PRIVATE_KEY`, while the prose
  describes an org-level `CRATES_PUBLISH_AUTOMATION_TOKEN`. I followed the
  YAML. Please confirm that is current and that the org exposes those to this
  repo.
- This repo has **zero tags and zero releases** — every version so far was
  published by hand. `0.10.17` is already on crates.io, so the first run
  through this path needs a version bump first.

## Verification

Run locally on this branch:

- `cargo check --all-targets --locked` with `RUSTFLAGS=-D warnings` — passes;
  the crate is rustc-warning-free today
- `cargo test --locked` — 18 passed, 1 ignored (the network test)
- `cargo package --locked` — succeeds with verification, emits
  `target/package/parity-publish-0.10.17.crate`
- Tag guard exercised against `v0.10.17` ✓, `0.10.17` ✓, `v0.10.18` ✗
- All four pinned action SHAs confirmed against their claimed tags via the
  GitHub API

**Not verified:** the `openssl` bump was never compiled locally — that path
only builds on Linux (macOS uses Security.framework), and `openssl-sys` goes
0.9.104 → 0.9.117, a build-script/system-header change. The new CI job is what
will actually prove it, so watch that run in particular.

[RUSTSEC-2025-0022]: https://rustsec.org/advisories/RUSTSEC-2025-0022.html
[RUSTSEC-2025-0004]: https://rustsec.org/advisories/RUSTSEC-2025-0004.html
[RUSTSEC-2025-0009]: https://rustsec.org/advisories/RUSTSEC-2025-0009.html
[cpa]: https://github.com/paritytech/crates_publish_automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
